### PR TITLE
Fix link to assembly project

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,5 +143,10 @@ Chartspree requires Redis. If you're deploying to heroku you can get an addon, s
 
 ### Configuring Chartspree
 
-Take a look at the `charts/settings.py` file for a list of environment variables that should be set in order for Charts to work correctly.
+Take a look at the `charts/settings.py` file for a list of environment variables that should be set 
+in order for Charts to work correctly.
 
+You can set these environment variables by creating a new file called `dev.env` in the root of the
+project and then use [Foreman](http://ddollar.github.io/foreman/) to run the application.
+
+    foreman start -e dev.env

--- a/charts/settings.py
+++ b/charts/settings.py
@@ -11,3 +11,4 @@ SERVICE_URL = os.getenv('SERVICE_URL') or 'http://example.com'
 CONTACT_EMAIL = os.getenv('CONTACT_EMAIL') or 'team@example.com'
 API_ROOT = os.getenv('API_ROOT') or '//example.com'
 FORMS_API = os.getenv('FORMS_API') or '//formspree.io' # for collecting feedback on the landing page
+ASSEMBLY_URL = os.getenv('ASSEMBLY_URL') or 'http://assembly.com'

--- a/charts/templates/index.html
+++ b/charts/templates/index.html
@@ -200,7 +200,7 @@ some cases may stretch layouts. So, we're just hiding it.
       <div class="container block">
           <div class="col-1-2">
 
-            <p>{{config.SERVICE_NAME}} is a tool maintained by the <a href="http://assembly.com/formspree">community at Assembly</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
+            <p>{{config.SERVICE_NAME}} is a tool maintained by the <a href={{config.ASSEMBLY_URL}}>community at Assembly</a>. To contact us send an email to <a href="mailto:{{config.CONTACT_EMAIL}}">{{config.CONTACT_EMAIL}}</a> or use the form on the right.</p>
 
           </div>
           <div class="col-1-2">


### PR DESCRIPTION
This is just a quick fix to the Assembly project link at the bottom of the index page. 

Instead of hard-coding the fix I used an environment variable because I noticed the gridspree and formspree appear to be using the same codebase. So I thought a variable was a better option and followed suite with what you're already using the environment variables for.

Also for whatever reason it took me a while to realize you're using Foreman. So I just called it out a bit more in the `README.md`.
